### PR TITLE
[ENG-1309] Changed version to 4.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-rights-exchange/chain-js-plugin-eos",
-  "version": "4.8.3",
+  "version": "4.8.2",
   "description": "Chain-js plug-in for EOS networks.",
   "license": "MIT",
   "main": "dist/cjs/src/index.js",


### PR DESCRIPTION
Switched the version back to `4.8.2` from `4.8.3` as the last commit was not published (tests failed) and the last published [version on npm](https://www.npmjs.com/package/@open-rights-exchange/chain-js-plugin-eos) is 4.8.1