### PR TITLE
fix: test configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint-fix": "eslint src --fix",
     "prepare": "npm run build",
     "prepublishOnly": "npm test && npm run lint",
-    "test": "jest --coverage",
+    "test": "jest --coverage --maxWorkers=1",
     "test:watch": "jest --watch",
     "localpublish": "zalc publish && zalc push",
     "build": "rm -fr dist/* && tsc -p tsconfig-mjs.json && tsc -p tsconfig-cjs.json && ./fixup",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-rights-exchange/chain-js-plugin-eos",
-  "version": "4.8.3",
+  "version": "4.8.2",
   "description": "Chain-js plug-in for EOS networks.",
   "license": "MIT",
   "main": "dist/cjs/src/index.js",


### PR DESCRIPTION
The problem is with jest in CI environment.
https://jestjs.io/pt-BR/docs/cli#--maxworkersnumstring

Jest by default tries to use as many treads as possible, which in CI environments can cause conflicts. A dica começou nesse post https://stackoverflow.com/questions/45087018/jest-simple-tests-are-slow

When testing with the flag, the test passed (and at my local, it was 1 second faster).

